### PR TITLE
Work around PyXML library bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: python
 
 python:
-  - "3.3"
-  - "3.2"
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"
+  - "3.6-dev"
+  - "nightly"
   - "pypy"
+  - "pypy3"
 
 install:
  - pip install -r requirements-test.txt

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -73,7 +73,7 @@ class Target(object):
 
 class RSS(Target):
     def start(self, handler, attrs):
-        if 'xml:base' in attrs:
+        if 'xml:base' in attrs.keys():
             handler.set_base(attrs.get('xml:base'))
 
 


### PR DESCRIPTION
With PyXML installed, xml.sax raises a "KeyError: 0" exception when trying to check if the "xml:base" attribute exists. PyXML is now unmaintained and shouldn't be installed, but we can't control the environment where it is deployed, so let's work around it.

See also: https://github.com/gpodder/gpodder/issues/185