### PR TITLE
understand atom updated field as published

### DIFF
--- a/podcastparser.py
+++ b/podcastparser.py
@@ -517,6 +517,12 @@ def parse_pubdate(text):
     >>> parse_pubdate('Fri, 21 Nov 1997 09:55:06 -0600')
     880127706
 
+    >>> parse_pubdate('2003-12-13T00:00:00+02:00')
+    1071266400
+
+    >>> parse_pubdate('2003-12-13T18:30:02Z')
+    1071340202
+
     >>> parse_pubdate('')
     0
 
@@ -530,11 +536,22 @@ def parse_pubdate(text):
     if parsed is not None:
         return int(mktime_tz(parsed))
 
-    # TODO: Fully RFC 3339-compliant parsing (w/ timezone)
     try:
         parsed = time.strptime(text[:19], '%Y-%m-%dT%H:%M:%S')
         if parsed is not None:
-            return int(time.mktime(parsed))
+            m = re.match(r'^(?:Z|([+-])([0-9]{2})[:]([0-9]{2}))$', text[19:])
+            if m:
+                parsed = list(iter(parsed))
+                if m.group(1):
+                    offset = 3600 * int(m.group(2)) + 60 * int(m.group(3))
+                    if m.group(1) == '-':
+                        offset = 0 - offset
+                else:
+                    offset = 0
+                parsed.append(offset)
+                return int(mktime_tz(tuple(parsed)))
+            else:
+                return int(time.mktime(parsed))
     except Exception:
         pass
 

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -584,6 +584,7 @@ MAPPING = {
     'atom:feed/atom:entry/atom:link': AtomLink(),
     'atom:feed/atom:entry/atom:content': AtomContent(),
     'atom:feed/atom:entry/atom:published': EpisodeAttr('published', parse_pubdate),
+    'atom:feed/atom:entry/atom:updated': EpisodeAttr('published', parse_pubdate),
     'atom:feed/atom:entry/media:group/media:description': EpisodeAttr('description', squash_whitespace),
     'atom:feed/atom:entry/psc:chapters': PodloveChapters(),
     'atom:feed/atom:entry/psc:chapters/psc:chapter': PodloveChapter(),

--- a/tests/data/atom_updated.json
+++ b/tests/data/atom_updated.json
@@ -3,7 +3,7 @@
                "guid": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
                "link": "http://example.org/2003/12/13/atom03",
                "payment_url": null,
-               "published": 1071336602,
+               "published": 1071270000,
                "title": "Atom-Powered Robots Run Amok",
                "total_time": 0}],
 "title": "Example Feed"}

--- a/tests/data/atom_updated.json
+++ b/tests/data/atom_updated.json
@@ -1,0 +1,9 @@
+{"episodes": [{"description": "",
+               "enclosures": [],
+               "guid": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
+               "link": "http://example.org/2003/12/13/atom03",
+               "payment_url": null,
+               "published": 1071336602,
+               "title": "Atom-Powered Robots Run Amok",
+               "total_time": 0}],
+"title": "Example Feed"}

--- a/tests/data/atom_updated.json
+++ b/tests/data/atom_updated.json
@@ -3,7 +3,7 @@
                "guid": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
                "link": "http://example.org/2003/12/13/atom03",
                "payment_url": null,
-               "published": 1071270000,
+               "published": 1071340202,
                "title": "Atom-Powered Robots Run Amok",
                "total_time": 0}],
 "title": "Example Feed"}

--- a/tests/data/atom_updated.rss
+++ b/tests/data/atom_updated.rss
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title>Example Feed</title>
+  <link href="http://example.org/"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>John Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+
+</feed>

--- a/tests/data/atom_updated.rss
+++ b/tests/data/atom_updated.rss
@@ -13,7 +13,7 @@
     <title>Atom-Powered Robots Run Amok</title>
     <link href="http://example.org/2003/12/13/atom03"/>
     <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
-    <updated>2003-12-13T00:00:00+00:00</updated>
+    <updated>2003-12-13T18:30:02Z</updated>
     <summary>Some text.</summary>
   </entry>
 

--- a/tests/data/atom_updated.rss
+++ b/tests/data/atom_updated.rss
@@ -13,7 +13,7 @@
     <title>Atom-Powered Robots Run Amok</title>
     <link href="http://example.org/2003/12/13/atom03"/>
     <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
-    <updated>2003-12-13T18:30:02Z</updated>
+    <updated>2003-12-13T00:00:00+00:00</updated>
     <summary>Some text.</summary>
   </entry>
 


### PR DESCRIPTION
Looks like it's the way to do it in podcastparser.
I need this for https://www.c3d2.de/news-atom.xml otherwise I get published = 1 jan. 1970