### PR TITLE
Ensure HTML is not exposed in the description member

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ The podcast parser project is a library from the gPodder project to provide an
 easy and reliable way of parsing RSS- and Atom-based podcast feeds in Python.
 
 * Web: http://gpodder.org/podcastparser/
+
+
+## Automated Tests
+
+To run the unit tests you need [`nose`](http://nose.readthedocs.io/en/latest/).  If you have `nose` installed, use the `nosetests` command in the repository's root directory to run the tests.

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -674,6 +674,13 @@ class PodcastHandler(sax.handler.ContentHandler):
         if len(entry['chapters']) == 0:
             del entry['chapters']
 
+        # Ensures `description` does not contain HTML
+        if 'description' in entry and is_html(entry['description']):
+            if 'description_html' not in entry:
+                entry['description_html'] = entry['description']
+            entry['description'] = ''
+
+        # Sets `description` to stripped `description_html` when absent
         if 'description_html' in entry and not entry['description']:
             entry['description'] = remove_html_tags(entry['description_html'])
 
@@ -833,6 +840,12 @@ def normalize_feed_url(url):
     # urlunsplit might return "a slighty different, but equivalent URL"
     return urlparse.urlunsplit((scheme, netloc, path, query, fragment))
 
+def is_html(text):
+    """
+    Tests whether the given string contains HTML encoded data
+    """
+    html_test = re.compile(r'<[a-z][\s\S]*>', re.IGNORECASE)
+    return bool(html_test.search(text))
 
 def remove_html_tags(html):
     """

--- a/tests/data/html_in_description.json
+++ b/tests/data/html_in_description.json
@@ -1,0 +1,22 @@
+{
+    "title": "HTML Podcast",
+    "episodes": [
+        {
+            "title": "Ep 1",
+            "description": "This is a test",
+            "description_html": "<h1>This is a <em>test</em></h1>",
+            "published": 0,
+            "guid": "http://example.org/example.opus",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.opus",
+                    "mime_type": "application/octet-stream"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/html_in_description.rss
+++ b/tests/data/html_in_description.rss
@@ -1,0 +1,12 @@
+<rss>
+    <channel>
+    <title>HTML Podcast</title>
+    <item>
+        <title>Ep 1</title>
+        <enclosure url="http://example.org/example.opus"/>
+        <description>
+            <![CDATA[ <h1>This is a <em>test</em></h1> ]]>
+        </description>
+    </item>
+    </channel>
+</rss>

--- a/tests/data/html_in_description_rss_both.json
+++ b/tests/data/html_in_description_rss_both.json
@@ -1,0 +1,22 @@
+{
+    "title": "HTML Podcast with Text Description",
+    "episodes": [
+        {
+            "title": "Ep 1",
+            "description": "This is also a test",
+            "description_html": "<h1>This is also a <em>test</em></h1>",
+            "published": 0,
+            "guid": "http://example.org/example.opus",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.opus",
+                    "mime_type": "application/octet-stream"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/html_in_description_rss_both.rss
+++ b/tests/data/html_in_description_rss_both.rss
@@ -1,0 +1,13 @@
+<rss>
+    <channel>
+    <title>HTML Podcast with Text Description</title>
+    <item>
+        <title>Ep 1</title>
+        <enclosure url="http://example.org/example.opus"/>
+        <content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <![CDATA[ <h1>This is also a <em>test</em></h1> ]]>
+        </content:encoded>
+        <description><![CDATA[ <h1>This is also a <em>test</em></h1> ]]></description>
+    </item>
+    </channel>
+</rss>

--- a/tests/data/html_in_description_rss_both_different.json
+++ b/tests/data/html_in_description_rss_both_different.json
@@ -1,0 +1,22 @@
+{
+    "title": "HTML Podcast with Text Description",
+    "episodes": [
+        {
+            "title": "Ep 1",
+            "description": "This is also a test",
+            "description_html": "<h1>This is also a <em>test</em></h1>",
+            "published": 0,
+            "guid": "http://example.org/example.opus",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.opus",
+                    "mime_type": "application/octet-stream"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/html_in_description_rss_both_different.rss
+++ b/tests/data/html_in_description_rss_both_different.rss
@@ -1,0 +1,13 @@
+<rss>
+    <channel>
+    <title>HTML Podcast with Text Description</title>
+    <item>
+        <title>Ep 1</title>
+        <enclosure url="http://example.org/example.opus"/>
+        <content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/">
+            <![CDATA[ <h1>This is also a <em>test</em></h1> ]]>
+        </content:encoded>
+        <description><![CDATA[ <h1>This text will be discarded</h1> ]]></description>
+    </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Alternative solution to  gpodder/gpodder#267.  This would be instead of #12.

This does as the tile says and ensures HTML is not exposed in the `description` member even when the original feed presents it that way.