### PR TITLE
Validate the root element of parsed XML

### DIFF
--- a/podcastparser.py
+++ b/podcastparser.py
@@ -769,7 +769,7 @@ def parse(url, stream, max_episodes=0):
     try:
         sax.parse(stream, handler)
     except sax.SAXParseException as e:
-        raise FeedParseError(e.message, e._exception, e._locator)
+        raise FeedParseError(e.getMessage(), e.getException(), e._locator)
     return handler.data
 
 

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -627,6 +627,16 @@ MAPPING = {
 }
 
 
+class FeedParseError(sax.SAXParseException, ValueError):
+    """
+    Exception raised when asked to parse an invalid feed
+    
+    This exception allows users of this library to catch exceptions
+    without having to import the XML parsing library themselves.
+    """
+    pass
+
+
 class PodcastHandler(sax.handler.ContentHandler):
     def __init__(self, url, max_episodes):
         self.url = url
@@ -734,16 +744,6 @@ class PodcastHandler(sax.handler.ContentHandler):
         if self.namespace is not None:
             self.namespace = self.namespace.parent
         self.path_stack.pop()
-
-
-class FeedParseError(sax.SAXParseException, ValueError):
-    """
-    Exception raised when asked to parse an invalid feed
-    
-    This exception allows users of this library to catch exceptions
-    without having to import the XML parsing library themselves.
-    """
-    pass
 
 
 def parse(url, stream, max_episodes=0):

--- a/test_podcastparser.py
+++ b/test_podcastparser.py
@@ -21,8 +21,11 @@
 import os
 import glob
 import json
+from StringIO import StringIO
+
 
 from nose.tools import assert_equal
+from nose.tools import assert_raises
 
 import podcastparser
 
@@ -50,3 +53,16 @@ def test_rss_parsing():
 
     for rss_filename in glob.glob(os.path.join('tests', 'data', '*.rss')):
         yield test_parse_rss, rss_filename
+
+def test_invalid_roots():
+    def test_fail_parse(feed):
+        with assert_raises(podcastparser.FeedParseError):
+            podcastparser.parse('file://example.com/feed.xml', StringIO(feed))
+
+    feeds = [
+        '<foo><bar/></foo>',
+        '<foo xmlns="http://example.com/foo.xml"><bar/></foo>',
+        '<baz:foo xmlns:baz="http://example.com/baz.xml"><baz:bar/></baz:foo>',
+    ]
+    for feed in feeds:
+        yield test_fail_parse, feed

--- a/test_podcastparser.py
+++ b/test_podcastparser.py
@@ -21,7 +21,12 @@
 import os
 import glob
 import json
-from StringIO import StringIO
+try:
+    # Python 2
+    from StringIO import StringIO
+except ImportError:
+    # Python 3
+    from io import StringIO
 
 
 from nose.tools import assert_equal

--- a/test_podcastparser.py
+++ b/test_podcastparser.py
@@ -65,7 +65,7 @@ def test_invalid_roots():
             podcastparser.parse('file://example.com/feed.xml', StringIO(feed))
 
     feeds = [
-        '<foo><bar/></foo>',
+        '<html><body/></html>',
         '<foo xmlns="http://example.com/foo.xml"><bar/></foo>',
         '<baz:foo xmlns:baz="http://example.com/baz.xml"><baz:bar/></baz:foo>',
     ]


### PR DESCRIPTION
This will make the SAX PodcastHandler check that root elements of XML it's asked to parse are elements it's designed to handle (defined by their presence in the MAPPING dict). It will raise a FeedParseError if not.

As mentioned in the discussion of gpodder/gpodder#261.