### PR TITLE
Implements automatic PyPI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,11 @@ script:
 
 after_script:
  - coveralls
+
+deploy:
+  provider: pypi
+  user: "gpodder"
+  password:
+    secure: "S0LtFa2Oz/srn78bQahypyMrp46jOHgucFYyGDGS+i9/fSar5zqyo+COX9vUsd3Lo7RRS00RPJDG5n/HSbH3x2LWUQRlltu51Qr8srC66lwjgkARjJbcbcyBBB+b0U8UYt5zns3CgJTWbrZ5tiN0Gtoq72ojfhiYuf54V4hRdlQ="
+  on:
+    tags: true


### PR DESCRIPTION
Counterpart to gpodder/mygpoclient#12.  Helps to facilitate gpodder/gpodder#293.  New release is needed for gpodder/gpodder#261.

Encrypted publication credentials need to be added by @thp.