### PR TITLE
Fix parsing of episode URL that have leading space

### DIFF
--- a/podcastparser.py
+++ b/podcastparser.py
@@ -174,7 +174,7 @@ class Enclosure(Target):
         if url is None:
             return
 
-        url = parse_url(urlparse.urljoin(handler.base, url))
+        url = parse_url(urlparse.urljoin(handler.base, url.lstrip()))
         file_size = parse_length(attrs.get(self.file_size_attribute))
         mime_type = parse_type(attrs.get('type'))
 

--- a/tests/data/leading_space_url.json
+++ b/tests/data/leading_space_url.json
@@ -1,0 +1,21 @@
+{
+  "title": "leading_space_url",
+  "episodes": [
+    {
+      "total_time": 0,
+      "description": "",
+      "payment_url": null,
+      "link": "",
+      "published": 0,
+      "title": "Episode",
+      "guid": "http://example.com/example.mp3",
+      "enclosures": [
+          {
+              "url": "http://example.com/example.mp3",
+              "mime_type": "application/octet-stream",
+              "file_size": -1
+          }
+      ]
+    }
+  ]
+}

--- a/tests/data/leading_space_url.rss
+++ b/tests/data/leading_space_url.rss
@@ -1,0 +1,8 @@
+<rss>
+    <channel>
+    <item>
+        <title>Episode</title>
+        <enclosure url=" http://example.com/example.mp3"/>
+    </item>
+    </channel>
+</rss>


### PR DESCRIPTION
If an episode URL has leading spaces, `urlparse.urljoin` produces a bad
URL, e.g. `http://base.url/ http://podcast.url/0.mp3`, which produces an
HTTP 404 error in gPodder. The patch strips the leading whitespace from
the URL before processing it.

This recently happened in the feed at
`http://www.magicreadalong.com/episode?format=RSS`:
`<enclosure url=" http://traffic.libsyn.com/magicreadalong/83_Baby_Bjorn.mp3" length="47497380" type="audio/mpeg"/>`