### PR TITLE
Prevent Atom updated dates overriding published

### DIFF
--- a/podcastparser.py
+++ b/podcastparser.py
@@ -70,9 +70,10 @@ logger = logging.getLogger(__name__)
 class Target(object):
     WANT_TEXT = False
 
-    def __init__(self, key=None, filter_func=lambda x: x.strip()):
+    def __init__(self, key=None, filter_func=lambda x: x.strip(), overwrite=True):
         self.key = key
         self.filter_func = filter_func
+        self.overwrite = overwrite
 
     def start(self, handler, attrs):
         pass
@@ -129,6 +130,8 @@ class EpisodeAttr(Target):
     WANT_TEXT = True
 
     def end(self, handler, text):
+        if not self.overwrite and handler.get_episode_attr(self.key):
+            return
         handler.set_episode_attr(self.key, self.filter_func(text))
 
 
@@ -620,7 +623,7 @@ MAPPING = {
     'atom:feed/atom:entry/atom:content': AtomContent(),
     'atom:feed/atom:entry/content:encoded': EpisodeAttr('description_html'),
     'atom:feed/atom:entry/atom:published': EpisodeAttr('published', parse_pubdate),
-    'atom:feed/atom:entry/atom:updated': EpisodeAttr('published', parse_pubdate),
+    'atom:feed/atom:entry/atom:updated': EpisodeAttr('published', parse_pubdate, overwrite=False),
     'atom:feed/atom:entry/media:group/media:description': EpisodeAttr('description', squash_whitespace),
     'atom:feed/atom:entry/psc:chapters': PodloveChapters(),
     'atom:feed/atom:entry/psc:chapters/psc:chapter': PodloveChapter(),

--- a/tests/data/atom_published_updated.json
+++ b/tests/data/atom_published_updated.json
@@ -1,0 +1,9 @@
+{"episodes": [{"description": "",
+               "enclosures": [],
+               "guid": "urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a",
+               "link": "http://example.org/2003/12/13/atom03",
+               "payment_url": null,
+               "published": 1071340202,
+               "title": "Atom-Powered Robots Run Amok",
+               "total_time": 0}],
+"title": "Example Feed"}

--- a/tests/data/atom_published_updated.rss
+++ b/tests/data/atom_published_updated.rss
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title>Example Feed</title>
+  <link href="http://example.org/"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>John Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <published>2003-12-13T18:30:02Z</published>
+    <updated>2017-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+
+</feed>


### PR DESCRIPTION
This should prevent using erroneous dates when an episode's `<updated>` comes after its `<published>` in the XML (gpodder/gpodder#394). 

This has been done by adding an `overwrite` arg to the `Target` base class, which is then implemented by `EpisodeAttr`. The argument could also be used by other `Target` subclasses if needed in future.