### PR TITLE
Add binding for episode artwork.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
-  - "3.6-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9-dev"
   - "nightly"
   - "pypy"
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -129,6 +129,9 @@ RSS
 **rss/channel/item/atom:link@rel=enclosure**
     File download URL (@href), size (@length) and mime type (@type).
 
+**rss/channel/item/itunes:image**
+    Episode art URL.
+
 **rss/channel/item/media:content**
     File download URL (@url), size (@fileSize) and mime type (@type).
 

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -626,6 +626,7 @@ MAPPING = {
     'rss/channel/item/itunes:duration': EpisodeAttr('total_time', parse_time),
     'rss/channel/item/pubDate': EpisodeAttr('published', parse_pubdate),
     'rss/channel/item/atom:link': AtomLink(),
+    'rss/channel/item/itunes:image': EpisodeAttrFromHref('episode_art_url'),
 
     'rss/channel/item/media:content': Enclosure('fileSize'),
     'rss/channel/item/enclosure': Enclosure('length'),

--- a/tests/data/itunes_episode_image.json
+++ b/tests/data/itunes_episode_image.json
@@ -1,0 +1,16 @@
+{
+  "title": "itunes_episode_image",
+  "episodes": [
+    {
+      "guid": "file://tests/data/a",
+      "title": "Namespace Test",
+      "enclosures": [],
+      "payment_url": null,
+      "episode_art_url": "http://example.com/episode/1.jpg",
+      "link": "file://tests/data/a",
+      "published": 0,
+      "description": "",
+      "total_time": 0
+    }
+  ]
+}

--- a/tests/data/itunes_episode_image.rss
+++ b/tests/data/itunes_episode_image.rss
@@ -1,0 +1,9 @@
+<rss xmlns:it="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <item>
+      <title>Namespace Test</title>
+      <guid>a</guid>
+      <itunes:image href="http://example.com/episode/1.jpg" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
This adds a binding that can be used for episode artwork.

I did not increment the version number (yet) since I don't know if this should be a minor or a major version number (would it break with older gpodders?).

Also maybe Python 2 related code should be removed?