### PR TITLE
urllib.request used over urllib for import

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,11 +43,11 @@ Example
 .. code-block:: python
 
     import podcastparser
-    import urllib
+    import urllib.request
 
     feedurl = 'http://example.com/feed.xml'
 
-    parsed = podcastparser.parse(feedurl, urllib.urlopen(feedurl))
+    parsed = podcastparser.parse(feedurl, urllib.request.urlopen(feedurl))
 
     # parsed is a dict
     import pprint


### PR DESCRIPTION
I was going through the docs and on Arch Linux with Python 3.8.5 the example did not work. After reading the docs on urllib, I determined that later implementations rely on urllib.request.