### PR TITLE
Fix parsing cover URL on a new line

### DIFF
--- a/podcastparser.py
+++ b/podcastparser.py
@@ -118,7 +118,7 @@ class PodcastAttrType(Target):
 
 class PodcastAttrRelativeLink(PodcastAttr):
     def end(self, handler, text):
-        text = urlparse.urljoin(handler.base, text)
+        text = urlparse.urljoin(handler.base, text.strip())
         super(PodcastAttrRelativeLink, self).end(handler, text)
 
 

--- a/tests/data/image_url_on_newline.json
+++ b/tests/data/image_url_on_newline.json
@@ -1,0 +1,5 @@
+{
+  "title": "image_url_on_newline",
+  "cover_url": "https://www.nps.gov/common/uploads/podcasts/0C4BEEC8-DDCF-0DBA-20016EC90B82DAEA.jpg",
+  "episodes": []
+}

--- a/tests/data/image_url_on_newline.rss
+++ b/tests/data/image_url_on_newline.rss
@@ -1,0 +1,11 @@
+<rss>
+    <channel>
+        <image>
+        <url>
+        https://www.nps.gov/common/uploads/podcasts/0C4BEEC8-DDCF-0DBA-20016EC90B82DAEA.jpg
+        </url>
+        <title>Headwaters</title>
+        <link>https://www.nps.gov/podcasts/headwaters.htm</link>
+        </image>
+    </channel>
+</rss>


### PR DESCRIPTION
If the feed's image URL is located on a new line, it's parsed with a
leading `\n`, creating an incorrect full URL and that makes gPodder
print a warning like this:

```
[gpodder.coverart] WARNING: Cover art download failed: URL can't contain control characters. '/rss/podcasts/\n\thttps:/www.nps.gov/common/uploads/podcasts/0C4BEEC8-DDCF-0DBA-20016EC90B82DAEA.jpg' (found at least '\n')
```

The issue was found with the [Headwaters Podcast][headwaters]'s feed at
https://www.nps.gov/rss/podcasts/podcast_xml.cfm?id=6705277. The part of
the RSS causing the issue is in the `image_url_on_newline.rss` test
file.

The fix is to `strip` all unnecessary whitespace from the URL.

Fixes https://github.com/gpodder/gpodder/issues/936.

[headwaters]: https://www.nps.gov/glac/learn/photosmultimedia/headwaters-podcast.htm