### PR TITLE
Support media:content tags under media:group

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -138,6 +138,9 @@ RSS
 **rss/channel/item/media:content**
     File download URL (@url), size (@fileSize) and mime type (@type).
 
+**rss/channel/item/media:group/media:content**
+    File download URL (@url), size (@fileSize) and mime type (@type).
+
 **rss/channel/item/enclosure**
     File download URL (@url), size (@length) and mime type (@type).
 

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -651,6 +651,7 @@ MAPPING = {
     'rss/channel/item/itunes:image': EpisodeAttrFromHref('episode_art_url'),
 
     'rss/channel/item/media:content': Enclosure('fileSize'),
+    'rss/channel/item/media:group/media:content': Enclosure('fileSize'),
     'rss/channel/item/enclosure': Enclosure('length'),
     'rss/channel/item/psc:chapters': PodloveChapters(),
     'rss/channel/item/psc:chapters/psc:chapter': PodloveChapter(),

--- a/tests/data/mediarss.json
+++ b/tests/data/mediarss.json
@@ -6,13 +6,18 @@
             "description": "",
             "published": 0,
             "guid": "http://example.org/example.mp3",
-            "link": "",
+            "link": "http://example.org/example.mp3",
             "total_time": 0,
             "payment_url": null,
             "enclosures": [
                 {
                     "file_size": 1234,
                     "url": "http://example.org/example.mp3",
+                    "mime_type": "audio/mpeg"
+                },
+                {
+                    "file_size": 2345,
+                    "url": "http://example.org/example2.mp3",
                     "mime_type": "audio/mpeg"
                 }
             ]

--- a/tests/data/mediarss.rss
+++ b/tests/data/mediarss.rss
@@ -3,7 +3,11 @@
     <title>Podcast</title>
     <item>
         <title>Episode</title>
+        <guid>http://example.org/example.mp3</guid>
         <media:content url="http://example.org/example.mp3" fileSize="1234" type="audio/mpeg"/>
+        <media:group>
+            <media:content url="http://example.org/example2.mp3" fileSize="2345" type="audio/mpeg"/>
+        </media:group>
     </item>
     </channel>
 </rss>


### PR DESCRIPTION
Some peertube RSS feeds have the actual media content URLs in media:group/media:content tags (example: https://tilvids.com/feeds/videos.xml?videoChannelId=42). This patch adds these tags to enclosures.