### PR TITLE
Prevent publish job from running in forks.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: >-
+      github.repository == 'gpodder/podcastparser' &&
       github.event_name == 'push' && (
         startsWith(github.ref, 'refs/tags') ||
         github.ref == 'refs/heads/master')


### PR DESCRIPTION
This will prevent failures when updating forks. But I'm not sure if it will interfer with publishing dev releases for pull requests that originate from forks.