### PR TITLE
Adds support and tests for elements from the podcast namespace...

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,6 +19,7 @@ The following specifications are supported:
 
 * `Paged Feeds`_ (`RFC 5005`_)
 * `Podlove Simple Chapters`_
+* `Podcast Index Podcast Namespace`_
 
 These formats only specify the possible markup elements and attributes. We
 recommend that you also read the `Podcast Feed Best Practice`_ guide if you
@@ -36,6 +37,7 @@ either as seconds or as `RFC 2326`_ Normal Play Time (NPT).
 .. _RFC 5005: https://tools.ietf.org/html/rfc5005
 .. _RFC 2326: https://tools.ietf.org/html/rfc2326
 .. _Podlove Simple Chapters: http://podlove.org/simple-chapters/
+.. _Podcast Index Podcast Namespace: https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md
 
 Example
 =======
@@ -116,6 +118,12 @@ RSS
 
 **rss/channel/itunes:new-feed-url**
     The new podcast RSS Feed URL.
+    
+**rss/channel/podcast:locked**
+    If the podcast is currently locked from being transferred.
+    
+**rss/channel/podcast:funding**
+    Funding link for podcast.
 
 **rss/redirect/newLocation**
     The new podcast RSS Feed URL.
@@ -199,6 +207,19 @@ RSS
 **rss/channel/item/itunes:episodeType**
     The episode type.
     This flag is used if an episode is a trailer or bonus content.
+    
+**rss/channel/item/podcast:chapters**
+    The url to a JSON file describing the chapters.
+    Only the url is added to the data as fetching an external URL would
+    be unsafe.
+    
+**rss/channel/item/podcast:person**
+    A person involved in the episode, e.g. host, or guest.
+    
+**rss/channel/item/podcast:transcript**
+    The url for the transcript file associated with this episode.
+    
+
 
 .. _Why RSS Content Module is Popular: https://developer.mozilla.org/en-US/docs/Web/RSS/Article/Why_RSS_Content_Module_is_Popular_-_Including_HTML_Contents
 

--- a/tests/data/episode_podcast_chapters.json
+++ b/tests/data/episode_podcast_chapters.json
@@ -1,0 +1,23 @@
+{
+    "title": "Podcast",
+    "episodes": [
+        {
+            "title": "Episode",
+            "description": "",
+            "published": 0,
+            "guid": "http://example.org/example.mp3",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "type": "trailer",
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.mp3",
+                    "mime_type": "application/octet-stream"
+                }
+            ],
+            "chapters_json_url": "https://example.com/1/chapters.json"
+        }
+    ]
+}

--- a/tests/data/episode_podcast_chapters.rss
+++ b/tests/data/episode_podcast_chapters.rss
@@ -1,0 +1,11 @@
+<rss>
+    <channel>
+    <title>Podcast</title>
+    <item>
+        <title>Episode</title>
+        <itunes:episodeType>trailer</itunes:episodeType>
+        <enclosure url="http://example.org/example.mp3"/>
+        <podcast:chapters url="https://example.com/1/chapters.json" type="application/json"/>
+    </item>
+    </channel>
+</rss>

--- a/tests/data/episode_podcast_person.json
+++ b/tests/data/episode_podcast_person.json
@@ -1,0 +1,38 @@
+{
+    "title": "Podcast",
+    "episodes": [
+        {
+            "title": "Episode",
+            "description": "",
+            "published": 0,
+            "guid": "http://example.org/example.mp3",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "type": "trailer",
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.mp3",
+                    "mime_type": "application/octet-stream"
+                }
+            ],
+            "people": [
+                {
+                    "name": "John Doe",
+                    "role": "host",
+                    "group": "cast",
+                    "href": "http://www.example.com",
+                    "img": "http://www.example.com/avatar.jpg"
+                },
+                {
+                    "name": "Stephanie Smith",
+                    "role": "guest",
+                    "group": "cast",
+                    "href": "http://amazingsite.com",
+                    "img": null
+                }
+            ]
+        }
+    ]
+}

--- a/tests/data/episode_podcast_person.rss
+++ b/tests/data/episode_podcast_person.rss
@@ -1,0 +1,12 @@
+<rss>
+    <channel>
+    <title>Podcast</title>
+    <item>
+        <title>Episode</title>
+        <itunes:episodeType>trailer</itunes:episodeType>
+        <enclosure url="http://example.org/example.mp3"/>
+        <podcast:person role="host" href="http://www.example.com" img="http://www.example.com/avatar.jpg" group="Cast">John Doe</podcast:person>
+        <podcast:person role="guest" href="http://amazingsite.com">Stephanie Smith</podcast:person>
+    </item>
+    </channel>
+</rss>

--- a/tests/data/episode_podcast_transcript.json
+++ b/tests/data/episode_podcast_transcript.json
@@ -1,0 +1,23 @@
+{
+    "title": "Podcast",
+    "episodes": [
+        {
+            "title": "Episode",
+            "description": "",
+            "published": 0,
+            "guid": "http://example.org/example.mp3",
+            "link": "",
+            "total_time": 0,
+            "payment_url": null,
+            "type": "trailer",
+            "enclosures": [
+                {
+                    "file_size": -1,
+                    "url": "http://example.org/example.mp3",
+                    "mime_type": "application/octet-stream"
+                }
+            ],
+            "transcript": "https://example.com/1/transcript.txt"
+        }
+    ]
+}

--- a/tests/data/episode_podcast_transcript.rss
+++ b/tests/data/episode_podcast_transcript.rss
@@ -1,0 +1,11 @@
+<rss>
+    <channel>
+    <title>Podcast</title>
+    <item>
+        <title>Episode</title>
+        <itunes:episodeType>trailer</itunes:episodeType>
+        <enclosure url="http://example.org/example.mp3"/>
+        <podcast:transcript type="text/plain" url="https://example.com/1/transcript.txt"/>
+    </item>
+    </channel>
+</rss>

--- a/tests/data/podcast_funding.json
+++ b/tests/data/podcast_funding.json
@@ -1,0 +1,5 @@
+{
+  "title": "podcast_funding",
+  "funding": "https://somecrowdfundingsite.com",
+  "episodes": []
+}

--- a/tests/data/podcast_funding.rss
+++ b/tests/data/podcast_funding.rss
@@ -1,0 +1,5 @@
+<rss>
+    <channel>
+        <podcast:funding url="https://somecrowdfundingsite.com">Support the show!</podcast:funding>
+    </channel>
+</rss>

--- a/tests/data/podcast_locked_feed.json
+++ b/tests/data/podcast_locked_feed.json
@@ -1,0 +1,5 @@
+{
+  "title": "podcast_locked_feed",
+  "locked": true,
+  "episodes": []
+}

--- a/tests/data/podcast_locked_feed.rss
+++ b/tests/data/podcast_locked_feed.rss
@@ -1,0 +1,5 @@
+<rss>
+    <channel>
+        <podcast:locked>yes</podcast:locked>
+    </channel>
+</rss>


### PR DESCRIPTION
... as specifyed by the podcast index.

Specifically adds support at channel level for:

- funding url
- locked boolean

And at the item level:

- chapters url for json description
- podcast person elements
- transcript url