### PR TITLE
Add rss/channel/itunes:summary handling

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -105,6 +105,9 @@ RSS
 **rss/channel/description**
     Podcast description (whitespace is squashed).
 
+**rss/channel/itunes:summary**
+    Podcast description (whitespace is squashed).
+
 **rss/channel/image/url**
     Podcast cover art.
 

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -76,12 +76,16 @@ class PodcastAttr(Target):
     WANT_TEXT = True
 
     def end(self, handler, text):
+        if not self.overwrite and handler.get_podcast_attr(self.key):
+            return
         handler.set_podcast_attr(self.key, self.filter_func(text))
 
 class PodcastAttrList(Target):
     WANT_TEXT = True
 
     def end(self, handler, text):
+        if not self.overwrite and handler.get_podcast_attr(self.key):
+            return
         handler.set_podcast_attr(self.key, self.filter_func(text).split(', '))
 
 
@@ -89,6 +93,8 @@ class PodcastAttrType(Target):
     WANT_TEXT = True
 
     def end(self, handler, text):
+        if not self.overwrite and handler.get_podcast_attr(self.key):
+            return
         value = self.filter_func(text)
         if value in ('episodic', 'serial'):
             handler.set_podcast_attr(self.key, value)
@@ -104,6 +110,8 @@ class PodcastAttrFromHref(Target):
     ATTRIBUTE = 'href'
     
     def start(self, handler, attrs):
+        if not self.overwrite and handler.get_podcast_attr(self.key):
+            return
         value = attrs.get(self.ATTRIBUTE)
         if value:
             value = urlparse.urljoin(handler.base, value)
@@ -842,6 +850,9 @@ class PodcastHandler(sax.handler.ContentHandler):
 
     def set_podcast_attr(self, key, value):
         self.data[key] = value
+
+    def get_podcast_attr(self, key, default=None):
+        return self.data.get(key, default)
 
     def set_episode_attr(self, key, value):
         self.episodes[-1][key] = value

--- a/podcastparser.py
+++ b/podcastparser.py
@@ -740,6 +740,7 @@ MAPPING = {
     'rss/channel/title': PodcastAttr('title', squash_whitespace),
     'rss/channel/link': PodcastAttrRelativeLink('link'),
     'rss/channel/description': PodcastAttr('description', squash_whitespace_not_nl),
+    'rss/channel/itunes:summary': PodcastAttr('description', squash_whitespace_not_nl, overwrite=False),
     'rss/channel/podcast:funding': PodcastAttrFromUrl('funding_url'),
     'rss/channel/podcast:locked': PodcastAttrExplicit('import_prohibited'),
     'rss/channel/image/url': PodcastAttrRelativeLink('cover_url'),

--- a/tests/data/channel_description.json
+++ b/tests/data/channel_description.json
@@ -1,0 +1,5 @@
+{
+	"title": "Example Feed",
+	"description": "A podcast with a description field",
+	"episodes": []
+}

--- a/tests/data/channel_description.rss
+++ b/tests/data/channel_description.rss
@@ -1,0 +1,6 @@
+<rss>
+    <channel>
+        <title>Example Feed</title>
+        <description>A podcast with a description field</description>
+    </channel>
+</rss>

--- a/tests/data/channel_summary.json
+++ b/tests/data/channel_summary.json
@@ -1,0 +1,5 @@
+{
+	"title": "Example Feed",
+	"description": "A podcast with a summary field",
+	"episodes": []
+}

--- a/tests/data/channel_summary.rss
+++ b/tests/data/channel_summary.rss
@@ -1,0 +1,6 @@
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <title>Example Feed</title>
+        <itunes:summary>A podcast with a summary field</itunes:summary>
+    </channel>
+</rss>

--- a/tests/data/channel_summary_and_description.json
+++ b/tests/data/channel_summary_and_description.json
@@ -1,0 +1,5 @@
+{
+	"title": "Example Feed",
+	"description": "A podcast with a description field",
+	"episodes": []
+}

--- a/tests/data/channel_summary_and_description.rss
+++ b/tests/data/channel_summary_and_description.rss
@@ -1,0 +1,7 @@
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <title>Example Feed</title>
+        <description>A podcast with a description field</description>
+        <itunes:summary>A podcast with a summary field</itunes:summary>
+    </channel>
+</rss>


### PR DESCRIPTION
We noticed that some podcasts don't have descriptions but do have itunes summaries.

Here's a file that can be used in a test: http://netstorage.discovery.com/ahc/podcasts/2016/ahc-ato-podcastrss.xml